### PR TITLE
Build release rather than debug version

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,7 @@ export CFLAGS="$CFLAGS -Wno-error"
 export ONLOAD_TREE=${SRC_DIR}/onload
 cd tcpdirect
 
-make -j${CPU_COUNT}
+make -j${CPU_COUNT} NDEBUG=1
 
 mkdir -p $PWD/release
 ln -sf $PWD/build/gnu_x86_64/bin $PWD/release/bin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     folder: onload
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:


### PR DESCRIPTION
According to build_and_copy_artifacts() in  scripts/zf_mkdist, packager must specify NDEBUG=1 explicitly, in order to build a release version of tcpdirect

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
